### PR TITLE
Use URL instead of key server for the GPG key on debian

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -7,8 +7,7 @@
 
 - name: import redirection.io apt key
   apt_key:
-    keyserver: keyserver.ubuntu.com
-    id: 24765BBD8E16EB44
+    url: https://packages.redirection.io/gpg.key 
     state: present
 
 - name: Install redirection.io repository


### PR DESCRIPTION
Otherwise it's not working.